### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -8,24 +8,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
 
       - name: "Log in to Docker Hub"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "Extract metadata (tags, labels) for Docker"
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4.2.0
         with:
           images: jmlemetayer/abba
           flavor: |
             latest=true
 
       - name: "Build and push Docker image"
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3.2.0
         with:
           context: docker
           push: true

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
 
       - name: "Setup python"
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.4.0
         with:
           python-version: 3.8
 
       - name: "Install Python dependencies"
-        uses: py-actions/py-dependency-install@v2
+        uses: py-actions/py-dependency-install@v4.0.0
         with:
           path: "tools/dependencies/requirements.txt"
 
@@ -30,7 +30,7 @@ jobs:
           ./tools/dependencies/update_dependencies
 
       - name: "Create Pull Request"
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4.2.3
         with:
           title: "Update dependencies"
           body: "ABBA dependency updates"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[py-actions/py-dependency-install](https://github.com/py-actions/py-dependency-install)** published a new release **[v4.0.0](https://github.com/py-actions/py-dependency-install/releases/tag/v4.0.0)** on 2022-11-06T18:23:13Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.4.0](https://github.com/actions/setup-python/releases/tag/v4.4.0)** on 2022-12-22T12:48:23Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v3.2.0](https://github.com/docker/build-push-action/releases/tag/v3.2.0)** on 2022-10-12T07:10:45Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.3.0](https://github.com/actions/checkout/releases/tag/v3.3.0)** on 2023-01-05T13:21:21Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v4.2.3](https://github.com/peter-evans/create-pull-request/releases/tag/v4.2.3)** on 2022-11-28T07:17:09Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v2.1.0](https://github.com/docker/login-action/releases/tag/v2.1.0)** on 2022-10-12T07:04:14Z
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v4.2.0](https://github.com/docker/metadata-action/releases/tag/v4.2.0)** on 2023-01-11T15:27:20Z
