### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3.3.0
 
       - name: "Setup python"
-        uses: actions/setup-python@v4.4.0
+        uses: actions/setup-python@v4.5.0
         with:
           python-version: 3.8
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.5.0](https://github.com/actions/setup-python/releases/tag/v4.5.0)** on 2023-01-12T11:29:27Z
