### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: "Extract metadata (tags, labels) for Docker"
         id: meta
-        uses: docker/metadata-action@v4.2.0
+        uses: docker/metadata-action@v4.3.0
         with:
           images: jmlemetayer/abba
           flavor: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v4.3.0](https://github.com/docker/metadata-action/releases/tag/v4.3.0)** on 2023-01-13T13:57:21Z
