### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -25,7 +25,7 @@ jobs:
             latest=true
 
       - name: "Build and push Docker image"
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v3.3.0
         with:
           context: docker
           push: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v3.3.0](https://github.com/docker/build-push-action/releases/tag/v3.3.0)** on 2023-01-14T09:21:58Z
