### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -10,12 +10,12 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.3.0
+      uses: actions/checkout@v3.4.0
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 
     - name: Run GitHub Actions Version Updater
-      uses: saadmk11/github-actions-version-updater@v0.7.3
+      uses: saadmk11/github-actions-version-updater@v0.7.4
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
         pull_request_branch: 'ghactions-autoupdate'

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.4.0
 
       - name: "Log in to Docker Hub"
         uses: docker/login-action@v2.1.0

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.4.0
 
       - name: "Setup python"
         uses: actions/setup-python@v4.5.0
@@ -30,7 +30,7 @@ jobs:
           ./tools/dependencies/update_dependencies
 
       - name: "Create Pull Request"
-        uses: peter-evans/create-pull-request@v4.2.3
+        uses: peter-evans/create-pull-request@v4.2.4
         with:
           title: "Update dependencies"
           body: "ABBA dependency updates"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v4.2.4](https://github.com/peter-evans/create-pull-request/releases/tag/v4.2.4)** on 2023-03-15T00:47:02Z
