### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.4.0
+      uses: actions/checkout@v3.5.0
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@v3.5.0
 
       - name: "Log in to Docker Hub"
         uses: docker/login-action@v2.1.0

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v3.4.0
+        uses: actions/checkout@v3.5.0
 
       - name: "Setup python"
         uses: actions/setup-python@v4.5.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.0](https://github.com/actions/checkout/releases/tag/v3.5.0)** on 2023-03-24T05:41:31Z
