### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -30,7 +30,7 @@ jobs:
           ./tools/dependencies/update_dependencies
 
       - name: "Create Pull Request"
-        uses: peter-evans/create-pull-request@v4.2.4
+        uses: peter-evans/create-pull-request@v5.0.0
         with:
           title: "Update dependencies"
           body: "ABBA dependency updates"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v5.0.0](https://github.com/peter-evans/create-pull-request/releases/tag/v5.0.0)** on 2023-04-04T23:48:39Z
