### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v3.5.2
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3.5.2
 
       - name: "Log in to Docker Hub"
         uses: docker/login-action@v2.1.0
@@ -18,7 +18,7 @@ jobs:
 
       - name: "Extract metadata (tags, labels) for Docker"
         id: meta
-        uses: docker/metadata-action@v4.3.0
+        uses: docker/metadata-action@v4.4.0
         with:
           images: jmlemetayer/abba
           flavor: |

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v3.5.2
 
       - name: "Setup python"
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4.6.0
         with:
           python-version: 3.8
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.1](https://github.com/actions/checkout/releases/tag/v3.5.1)** on 2023-04-12T15:13:40Z
