### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -30,7 +30,7 @@ jobs:
           ./tools/dependencies/update_dependencies
 
       - name: "Create Pull Request"
-        uses: peter-evans/create-pull-request@v5.0.0
+        uses: peter-evans/create-pull-request@v5.0.1
         with:
           title: "Update dependencies"
           body: "ABBA dependency updates"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v5.0.1](https://github.com/peter-evans/create-pull-request/releases/tag/v5.0.1)** on 2023-05-02T01:46:20Z
