### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3.5.2
 
       - name: "Setup python"
-        uses: actions/setup-python@v4.6.0
+        uses: actions/setup-python@v4.6.1
         with:
           python-version: 3.8
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.6.1](https://github.com/actions/setup-python/releases/tag/v4.6.1)** on 2023-05-24T14:12:35Z
