### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -18,14 +18,14 @@ jobs:
 
       - name: "Extract metadata (tags, labels) for Docker"
         id: meta
-        uses: docker/metadata-action@v4.5.0
+        uses: docker/metadata-action@v4.6.0
         with:
           images: jmlemetayer/abba
           flavor: |
             latest=true
 
       - name: "Build and push Docker image"
-        uses: docker/build-push-action@v4.1.0
+        uses: docker/build-push-action@v4.1.1
         with:
           context: docker
           push: true

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -30,7 +30,7 @@ jobs:
           ./tools/dependencies/update_dependencies
 
       - name: "Create Pull Request"
-        uses: peter-evans/create-pull-request@v5.0.1
+        uses: peter-evans/create-pull-request@v5.0.2
         with:
           title: "Update dependencies"
           body: "ABBA dependency updates"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v5.0.2](https://github.com/peter-evans/create-pull-request/releases/tag/v5.0.2)** on 2023-06-14T01:20:17Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v4.1.1](https://github.com/docker/build-push-action/releases/tag/v4.1.1)** on 2023-06-13T11:22:58Z
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v4.6.0](https://github.com/docker/metadata-action/releases/tag/v4.6.0)** on 2023-06-13T10:28:40Z
