### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3.5.3
 
       - name: "Setup python"
-        uses: actions/setup-python@v4.6.1
+        uses: actions/setup-python@v4.7.0
         with:
           python-version: 3.8
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.7.0](https://github.com/actions/setup-python/releases/tag/v4.7.0)** on 2023-07-13T14:05:58Z
