### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -15,7 +15,7 @@ jobs:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 
     - name: Run GitHub Actions Version Updater
-      uses: saadmk11/github-actions-version-updater@v0.7.4
+      uses: saadmk11/github-actions-version-updater@v0.8.1
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
         pull_request_branch: 'ghactions-autoupdate'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.0](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.0)** on 2023-08-06T06:09:30Z
