### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -25,7 +25,7 @@ jobs:
             latest=true
 
       - name: "Build and push Docker image"
-        uses: docker/build-push-action@v4.1.1
+        uses: docker/build-push-action@v4.2.1
         with:
           context: docker
           push: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v4.2.1](https://github.com/docker/build-push-action/releases/tag/v4.2.1)** on 2023-09-08T13:39:30Z
