### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v4.0.0
+      uses: actions/checkout@v4.2.2
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -8,24 +8,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v4.2.2
 
       - name: "Log in to Docker Hub"
-        uses: docker/login-action@v2.2.0
+        uses: docker/login-action@v3.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "Extract metadata (tags, labels) for Docker"
         id: meta
-        uses: docker/metadata-action@v4.6.0
+        uses: docker/metadata-action@v5.7.0
         with:
           images: jmlemetayer/abba
           flavor: |
             latest=true
 
       - name: "Build and push Docker image"
-        uses: docker/build-push-action@v4.2.1
+        uses: docker/build-push-action@v6.18.0
         with:
           context: docker
           push: true

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -11,15 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out the repo"
-        uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v4.2.2
 
       - name: "Setup python"
-        uses: actions/setup-python@v4.7.0
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: 3.8
 
       - name: "Install Python dependencies"
-        uses: py-actions/py-dependency-install@v4.0.0
+        uses: py-actions/py-dependency-install@v4.1.0
         with:
           path: "tools/dependencies/requirements.txt"
 
@@ -30,7 +30,7 @@ jobs:
           ./tools/dependencies/update_dependencies
 
       - name: "Create Pull Request"
-        uses: peter-evans/create-pull-request@v5.0.2
+        uses: peter-evans/create-pull-request@v7.0.8
         with:
           title: "Update dependencies"
           body: "ABBA dependency updates"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.0.0](https://github.com/docker/login-action/releases/tag/v3.0.0)** on 2023-09-12T07:51:46Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v5.0.0](https://github.com/docker/build-push-action/releases/tag/v5.0.0)** on 2023-09-12T07:46:14Z
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v5.0.0](https://github.com/docker/metadata-action/releases/tag/v5.0.0)** on 2023-09-12T07:55:31Z
